### PR TITLE
Add lxdhub to open source examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@
 
 - Open Source
   - [evebook/api](https://github.com/evebook/api) :milky_way: EVE Book API
+  - [roche/lxdhub](https://github.com/Roche/lxdhub): Management system for Linux Containers (LXC).
 - Enterprise Usage
 
 ## Components & Libraries


### PR DESCRIPTION
Do not know if LXDHub should be in the **Enterprise Usage** or **Open Source** column, since it is used for Enterprise but is open sourced